### PR TITLE
Add Logic Level setting support to sysfs and channel to Watcher.

### DIFF
--- a/io.go
+++ b/io.go
@@ -8,22 +8,20 @@ import (
 
 // Pin represents a single pin, which can be used either for reading or writing
 type Pin struct {
-	Number     uint
-	direction  Direction
-	logicLevel LogicLevel
-	f          *os.File
+	Number    uint
+	direction direction
+	f         *os.File
 }
 
 // NewInput opens the given pin number for reading. The number provided should be the pin number known by the kernel
-func NewInput(p uint, logicLevel LogicLevel) Pin {
+func NewInput(p uint) Pin {
 	pin := Pin{
 		Number: p,
 	}
 	exportGPIO(pin)
 	time.Sleep(10 * time.Millisecond)
-	pin.direction = InDirection
-	setDirection(pin, InDirection, 0)
-	setLogicLevel(pin, logicLevel)
+	pin.direction = inDirection
+	setDirection(pin, inDirection, 0)
 	pin = openPin(pin, false)
 	return pin
 }
@@ -40,8 +38,8 @@ func NewOutput(p uint, initHigh bool) Pin {
 	if initHigh {
 		initVal = uint(1)
 	}
-	pin.direction = OutDirection
-	setDirection(pin, OutDirection, initVal)
+	pin.direction = outDirection
+	setDirection(pin, outDirection, initVal)
 	pin = openPin(pin, true)
 	return pin
 }
@@ -52,16 +50,22 @@ func (p Pin) Close() {
 }
 
 // Read returns the value read at the pin as reported by the kernel. This should only be used for input pins
-func (p Pin) Read() (value Value, err error) {
-	if p.direction != InDirection {
+func (p Pin) Read() (value uint, err error) {
+	if p.direction != inDirection {
 		return 0, errors.New("pin is not configured for input")
 	}
 	return readPin(p)
 }
 
+// SetLogicLevel sets the logic level for the Pin. This can be
+// either "active high" or "active low"
+func (p Pin) SetLogicLevel(logicLevel LogicLevel) error {
+	return setLogicLevel(p, logicLevel)
+}
+
 // High sets the value of an output pin to logic high
 func (p Pin) High() error {
-	if p.direction != OutDirection {
+	if p.direction != outDirection {
 		return errors.New("pin is not configured for output")
 	}
 	return writePin(p, 1)
@@ -69,7 +73,7 @@ func (p Pin) High() error {
 
 // Low sets the value of an output pin to logic low
 func (p Pin) Low() error {
-	if p.direction != OutDirection {
+	if p.direction != outDirection {
 		return errors.New("pin is not configured for output")
 	}
 	return writePin(p, 0)

--- a/sysfs.go
+++ b/sysfs.go
@@ -7,11 +7,11 @@ import (
 	"strconv"
 )
 
-type Direction uint
+type direction uint
 
 const (
-	InDirection Direction = iota
-	OutDirection
+	inDirection direction = iota
+	outDirection
 )
 
 type Edge uint
@@ -57,7 +57,7 @@ func unexportGPIO(p Pin) {
 	export.Write([]byte(strconv.Itoa(int(p.Number))))
 }
 
-func setDirection(p Pin, d Direction, initialValue uint) {
+func setDirection(p Pin, d direction, initialValue uint) {
 	dir, err := os.OpenFile(fmt.Sprintf("/sys/class/gpio/gpio%d/direction", p.Number), os.O_WRONLY, 0600)
 	if err != nil {
 		fmt.Printf("failed to open gpio %d direction file for writing\n", p.Number)
@@ -66,11 +66,11 @@ func setDirection(p Pin, d Direction, initialValue uint) {
 	defer dir.Close()
 
 	switch {
-	case d == InDirection:
+	case d == inDirection:
 		dir.Write([]byte("in"))
-	case d == OutDirection && initialValue == 0:
+	case d == outDirection && initialValue == 0:
 		dir.Write([]byte("low"))
-	case d == OutDirection && initialValue == 1:
+	case d == outDirection && initialValue == 1:
 		dir.Write([]byte("high"))
 	default:
 		panic(fmt.Sprintf("setDirection called with invalid direction or initialValue, %d, %d", d, initialValue))
@@ -131,7 +131,7 @@ func openPin(p Pin, write bool) Pin {
 	return p
 }
 
-func readPin(p Pin) (val Value, err error) {
+func readPin(p Pin) (val uint, err error) {
 	file := p.f
 	file.Seek(0, 0)
 	buf := make([]byte, 1)
@@ -150,7 +150,7 @@ func readPin(p Pin) (val Value, err error) {
 	}
 }
 
-func writePin(p Pin, v Value) error {
+func writePin(p Pin, v uint) error {
 	var buf []byte
 	switch v {
 	case 0:

--- a/watcher.go
+++ b/watcher.go
@@ -199,14 +199,21 @@ func (w *Watcher) watch() {
 	}
 }
 
-// AddPin adds a new pin to be watched for changes
+// AddPin adds a new pin to be watched for changes.
+// The pin is configured with logic level "active high"
+// and watched for both rising and falling edges.
 // The pin provided should be the pin known by the kernel
 func (w *Watcher) AddPin(p uint) {
-	w.AddPinWithEdgeAndLogic(p, ActiveHigh, EdgeBoth)
+	w.AddPinWithEdgeAndLogic(p, EdgeBoth, ActiveHigh)
 }
 
-func (w *Watcher) AddPinWithEdgeAndLogic(p uint, logicLevel LogicLevel, edge Edge) {
-	pin := NewInput(p, logicLevel)
+// AddPinWithEdgeAndLogic adds a new pin to be watched for changes.
+// Edges can be configured to be either rising, falling, or both.
+// Logic level can be active high or active low.
+// The pin provided should be the pin known by the kernel.
+func (w *Watcher) AddPinWithEdgeAndLogic(p uint, edge Edge, logicLevel LogicLevel) {
+	pin := NewInput(p)
+	setLogicLevel(pin, logicLevel)
 	setEdgeTrigger(pin, edge)
 	w.cmdChan <- watcherCmd{
 		pin:    pin,

--- a/watcher.go
+++ b/watcher.go
@@ -23,8 +23,8 @@ type watcherCmd struct {
 }
 
 type WatcherNotify struct {
-	pin   Pin
-	value Value
+	Pin   Pin
+	Value Value
 }
 
 type fdHeap []uintptr
@@ -94,8 +94,8 @@ func (w *Watcher) notify(fdset *syscall.FdSet) {
 				os.Exit(1)
 			}
 			msg := WatcherNotify{
-				pin:   pin,
-				value: val,
+				Pin:   pin,
+				Value: val,
 			}
 			select {
 			case w.NotifyChan <- msg:
@@ -229,7 +229,7 @@ func (w *Watcher) RemovePin(p uint) {
 // Also, if the input is connected to a mechanical switch, the user of this library must deal with debouncing
 func (w *Watcher) Watch() (p uint, v Value) {
 	notification := <-w.NotifyChan
-	return notification.pin.Number, notification.value
+	return notification.Pin.Number, notification.Value
 }
 
 // Close stops the watcher and releases all resources


### PR DESCRIPTION
Adds support for setting the "active_low" value for a given pin. Let's clients control whether "1" indicates low voltage or high voltage.

Adds support for setting the Edge and LogicLevel when watching a Pin with the Watcher.

Exposes the WatcherNotify channel for the watcher so clients can watch
these values directly without blocking or creating a separate channel.