### PR TITLE
Unexport GPIO on Pin closing

### DIFF
--- a/io.go
+++ b/io.go
@@ -47,6 +47,7 @@ func NewOutput(p uint, initHigh bool) Pin {
 // Close releases the resources related to Pin
 func (p Pin) Close() {
 	p.f.Close()
+	unexportGPIO(p)
 }
 
 // Read returns the value read at the pin as reported by the kernel. This should only be used for input pins

--- a/io.go
+++ b/io.go
@@ -44,9 +44,17 @@ func NewOutput(p uint, initHigh bool) Pin {
 	return pin
 }
 
-// Close releases the resources related to Pin
+// Close releases the resources related to Pin. This doen't unexport Pin, use Cleanup() instead
 func (p Pin) Close() {
-	p.f.Close()
+	if p.f != nil {
+		p.f.Close()
+		p.f = nil
+	}
+}
+
+// Cleanup close Pin and unexport it
+func (p Pin) Cleanup() {
+	p.Close()
 	unexportGPIO(p)
 }
 


### PR DESCRIPTION
Hi @brian-armstrong,

I made this little PR to fix the gpio.Close() method, ensuring Pin is unexported when we close it.